### PR TITLE
mbedtls: mutex initialisation on Windows

### DIFF
--- a/library/threading.c
+++ b/library/threading.c
@@ -97,7 +97,7 @@ int mbedtls_threading_trylock = 1;
 #if defined(MBEDTLS_THREADING_WINDOWS)
 static void threading_mutex_init_windows( mbedtls_threading_mutex_t *mutex )
 {
-    if( mutex == NULL || mutex->is_valid )
+    if( mutex == NULL )
         return;
 
     InitializeCriticalSection( &mutex->cs );


### PR DESCRIPTION
Change `threading_mutex_init_windows` to match `threading_mutex_init_pthread` behaviour (https://github.com/Devolutions/mbedtls/blob/development/library/threading.c#L71).

The check of `mutex->is_valid` is not valid (!) because the mutex parameter may not have been initialized yet.

This can crash us e.g. when initializing entropy

Alternative fix would be here: https://github.com/Devolutions/mbedtls/blob/development/library/entropy.c#L68. We could zero the entire `ctx` instead of `ctx->source`.